### PR TITLE
Make XCUIDebug usable as a test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .target(
+        .testTarget(
             name: "XCUIDebug",
             path: "Sources/XCUIDebug"
         )


### PR DESCRIPTION
## Summary
- mark `XCUIDebug` as a test target so it can be linked in UI test bundles

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_6899047f24b083229d6b21ae61f30124