### PR TITLE
Add example project to test XCUIDebug linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+**/.build/
+**/.swiftpm/

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/
+.netrc

--- a/example/Package.swift
+++ b/example/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "ExampleApp",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15)
+    ],
+    dependencies: [
+        .package(path: "..")
+    ],
+    targets: [
+        .executableTarget(
+            name: "ExampleApp",
+            dependencies: ["XCUIDebug"]
+        )
+    ]
+)

--- a/example/Sources/ExampleApp/main.swift
+++ b/example/Sources/ExampleApp/main.swift
@@ -1,0 +1,8 @@
+import XCUIDebug
+
+@main
+struct ExampleApp {
+    static func main() {
+        print("XCUIDebug available: \(DebugProxy.self)")
+    }
+}


### PR DESCRIPTION
## Summary
- add an executable example package importing XCUIDebug via a relative path
- ignore build artifacts for nested Swift packages
- rename the example executable target to `ExampleApp` and ignore the entire `.swiftpm` folder

## Testing
- `swift build` *(fails: cannot infer contextual base in reference to member 'any')*
- `cd example && swift build` *(fails: cannot infer contextual base in reference to member 'any')*


------
https://chatgpt.com/codex/tasks/task_e_689905802534832288e7e91708b55c22